### PR TITLE
비디오 리스트 업데이트 이슈 수정 및 비디오 CRUD함수 개선

### DIFF
--- a/VideoRecorder/Presentation/Play/ViewModel/PlayVideoItemViewModel.swift
+++ b/VideoRecorder/Presentation/Play/ViewModel/PlayVideoItemViewModel.swift
@@ -28,15 +28,14 @@ extension PlayVideoItemViewModel {
     }
     
     func makeURL(id: String) -> URL {
-        guard let (dirUrl, _) = MediaFileManager.shared.createUrl() else {
-            return URL(string: "")!
-        }
+        let dirUrl = MediaFileManager.shared.createUrl(path: .videos)
+//        guard let (dirUrl, _) = MediaFileManager.shared.createUrl() else {
+//            return URL(string: "")!
+//        }
 
-        let newUrl = dirUrl.appendingPathComponent("\(id).mp4")
+        let newUrl = dirUrl!.appendingPathComponent("\(id).mp4")
         
         print(newUrl)
-        print("!!!!!")
-        print(URL(string: "file://" + (self.thumbnailImagePath.value ?? ""))!)
         // 로컬 path 로 부터 mp4 영상 player 에 import
         return newUrl
     }

--- a/VideoRecorder/Presentation/Record/View/RecordViewController.swift
+++ b/VideoRecorder/Presentation/Record/View/RecordViewController.swift
@@ -113,22 +113,9 @@ class RecordViewController: UIViewController {
         setupConstraints()
         configureView()
         
-        switch AVCaptureDevice.authorizationStatus(for: .video) {
-        case .authorized: // The user has previously granted access to the camera.
-            self.viewModel.setupSession()
-        case .notDetermined: // The user has not yet been asked for camera access.
-            AVCaptureDevice.requestAccess(for: .video) { granted in
-                if granted {
-                    self.viewModel.setupSession()
-                }
-            }
-
-        case .denied: // The user has previously denied access.
-            return
-
-        case .restricted: // The user can't grant access due to restrictions.
-            return
-        }
+//        viewModel.checkAuthorization { isAuth in
+//            self.viewModel.setupSession()
+//        }
     }
     
     deinit {

--- a/VideoRecorder/Presentation/Record/View/RecordViewController.swift
+++ b/VideoRecorder/Presentation/Record/View/RecordViewController.swift
@@ -200,23 +200,27 @@ extension RecordViewController: AVCaptureFileOutputRecordingDelegate {
         
         let nowDate = Date(timeInterval: 32400, since: Date())
         let duration = Int(output.recordedDuration.seconds)
-        let position = viewModel.captureSession.inputs.first?.ports.first?.sourceDevicePosition
         
         self.askForTextAndConfirmWithAlert(title: "알림", placeholder: "영상의 제목을 입력해주세요") { [weak self]
             filename in
-            
+
             guard let self = self else { return }
             
-            guard let filename = filename else {
-                MediaFileManager.shared.deleteMedia(self.uuid!.uuidString)
+            guard let filename = filename else { // 취소시 저장된 영상은 삭제처리.
+                if !MediaFileManager.shared.deleteVideo(id: self.uuid!.uuidString) {
+                    print("영상이 완전히 삭제되지않음 id: \(self.uuid!.uuidString)")
+                }
                 return
             }
             
-            let model = Video(id: self.uuid!.uuidString, title: filename, releaseDate: nowDate, duration: duration, thumbnailPath: outputFileURL.absoluteString)
-            MediaFileManager.shared.storeMediaInfo(video: model)
+            let video = Video(id: self.uuid!.uuidString, title: filename, releaseDate: nowDate, duration: duration, thumbnailPath: outputFileURL.absoluteString)
             
-            let param = FirebaseStorageManager.StorageParameter(id: self.uuid!.uuidString, filename: filename, url: outputFileURL)
-            FirebaseStorageManager.shared.backup(param)
+            if MediaFileManager.shared.addVideo(video: video) {
+                let param = FirebaseStorageManager.StorageParameter(id: self.uuid!.uuidString, url: outputFileURL)
+                FirebaseStorageManager.shared.backup(param) { isUploaded in
+                    // backup task end
+                }
+            }
         }
     }
     
@@ -244,13 +248,15 @@ extension RecordViewController {
         self.timeLabel.text = duration
     }
     
-    // Recording Methods
     @objc func startRecording() {
-//        guard let videoOutput = viewModel.videoOutput else {
-//            print("No video Output")
-//            finishRecording()
-//            return
-//        }
+        
+        guard let videoOutput = viewModel.videoOutput else {
+            print("No video Output")
+            // MARK: TEST
+            test_finish_recording()
+            return
+        }
+        
         if viewModel.videoOutput.isRecording {
             stopRecording()
             return
@@ -266,10 +272,7 @@ extension RecordViewController {
             self.recordButton.transform = CGAffineTransform(scaleX: 0.75, y: 0.75)
         }
         
-        guard let (dirUrl, _) = MediaFileManager.shared.createUrl() else {
-            return
-        }
-        
+        guard let dirUrl = MediaFileManager.shared.createUrl(path: .videos) else { return }
         uuid = UUID()
         let saveUrl = dirUrl.appendingPathComponent("\(uuid!.uuidString).mp4")
         viewModel.videoOutput.startRecording(to: saveUrl, recordingDelegate: self)
@@ -285,6 +288,46 @@ extension RecordViewController {
                 self.recordButton.transform = CGAffineTransform(scaleX: 1.0, y: 1.0)
             }
             swapCameraPositionButton.isEnabled = true
+        }
+    }
+}
+
+// MARK: TEST
+extension RecordViewController {
+    /*
+        Mock data를 생성
+        이름 설정시 data를 저장 및 백업
+        미설정 시 data를 삭제
+     */
+    func test_finish_recording() {
+        uuid = UUID()
+        self.askForTextAndConfirmWithAlert(title: "알림", placeholder: "영상의 제목을 입력해주세요") { [weak self]
+            filename in
+            
+            guard let self = self else { return }
+            
+            // 이름 미지정시 생성되엇던 영상 삭제
+            guard let filename = filename else { // 취소시 저장된 영상은 삭제처리.
+                if !MediaFileManager.shared.deleteVideo(id: self.uuid!.uuidString) {
+                    print("영상이 완전히 삭제되지않음 id: \(self.uuid!.uuidString)")
+                }
+                return
+            }
+            
+            // add dummy
+            var videoUrl = MediaFileManager.shared.createUrl(path: .videos)
+            videoUrl = videoUrl?.appendingPathComponent(self.uuid!.uuidString, conformingTo: .mpeg4Movie)
+            let outputFileURL = MediaFileManager.shared.addDummy(url: videoUrl!)
+            
+            // add video, backup
+            let video = Video(id: self.uuid!.uuidString, title: filename, releaseDate: Date(), duration: 4, thumbnailPath: outputFileURL!.relativePath)
+            if MediaFileManager.shared.addVideo(video: video) {
+                let param = FirebaseStorageManager.StorageParameter(id: self.uuid!.uuidString, url: outputFileURL!)
+                FirebaseStorageManager.shared.backup(param) { isUploaded in
+                    // backup task end
+                    }
+                }
+            }
         }
     }
 }

--- a/VideoRecorder/Presentation/Record/ViewModel/RecordViewModel.swift
+++ b/VideoRecorder/Presentation/Record/ViewModel/RecordViewModel.swift
@@ -18,6 +18,30 @@ class RecordViewModel {
 
 extension RecordViewModel {
     
+    func checkAuthorization(_ completion: @escaping (Bool) -> Void) {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized: // The user has previously granted access to the camera.
+            // setup session
+            completion(true)
+            return
+            
+        case .notDetermined: // The user has not yet been asked for camera access.
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                completion(granted)
+            }
+
+        case .denied: // The user has previously denied access.
+            completion(false)
+            return
+            
+        case .restricted: // The user can't grant access due to restrictions.
+            completion(false)
+            return
+        @unknown default:
+            fatalError("unknown authorizationStatus")
+        }
+    }
+    
     func setupSession() {
         captureSession.sessionPreset = .high
         

--- a/VideoRecorder/Presentation/VideoList/View/VideoListViewController.swift
+++ b/VideoRecorder/Presentation/VideoList/View/VideoListViewController.swift
@@ -34,6 +34,7 @@ class VideoListViewController: UIViewController {
     
     let cameraButton: UIButton = {
         let view = UIButton()
+        view.accessibilityIdentifier = "camera"
         view.setImage(UIImage(systemName: "video.fill"), for: .normal)
         view.contentHorizontalAlignment = .fill
         view.contentVerticalAlignment = .fill
@@ -66,13 +67,10 @@ class VideoListViewController: UIViewController {
         setupConstraints()
         configureView()
         bind()
-//        notificationRegister()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         self.navigationController?.isNavigationBarHidden = true
-        self.viewModel.items = MediaFileManager.shared.fetchJson()
-        updateItems()
     }
 }
 
@@ -144,18 +142,9 @@ extension VideoListViewController {
         videoListView.reloadData()
     }
     
-//    func notificationRegister() {
-//        NotificationCenter.default.addObserver(forName: Notification.Name("mediaInfo_updated"), object: nil, queue: .main) { [weak self] _ in
-//            guard let self = self else { return }
-//            self.works.append(self.updateItems)
-//        }
-//    }
-    
     @objc func showRecordVC() {
-        let vc = RecordViewController()
-        vc.modalPresentationStyle = .fullScreen
-        vc.modalTransitionStyle = .coverVertical
-        self.present(vc, animated: true)
+        let recordVC = RecordViewController(listViewModel: viewModel)
+        self.navigationController?.pushViewController(recordVC, animated: true)
     }
 }
 

--- a/VideoRecorder/Presentation/VideoList/ViewModel/VideoListViewModel.swift
+++ b/VideoRecorder/Presentation/VideoList/ViewModel/VideoListViewModel.swift
@@ -53,7 +53,10 @@ extension VideoListViewModel {
         Task {
             // MARK: - 로컬부터 파일삭제
             if await FirebaseStorageManager.shared.delete(video.id.value) {
-                MediaFileManager.shared.deleteMedia(video.id.value)
+                if !MediaFileManager.shared.deleteVideo(id: video.id.value) {
+                    // failed delete video
+                    // but 보이는 리스트에서는 일시적으로 삭제됨.
+                }
             }
         }
         self.items.remove(at: index)

--- a/VideoRecorder/SceneDelegate.swift
+++ b/VideoRecorder/SceneDelegate.swift
@@ -19,12 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         
-        guard let (dirUrl, _) = MediaFileManager.shared.createUrl() else {
-            return
-        }
-        print(dirUrl)
-        
-        let videos = MediaFileManager.shared.fetchJson()
+        let videos = try! MediaFileManager.shared.getVideos()
         let testViewModel = VideoListViewModel(videoItems: videos)
         
         let mainViewController = VideoListViewController(viewModel: testViewModel)

--- a/VideoRecorder/Utils/MediaFileManager.swift
+++ b/VideoRecorder/Utils/MediaFileManager.swift
@@ -12,75 +12,100 @@ import Foundation
  */
 class MediaFileManager {
     
-    enum FileManagerError: Error {
-        case failedStoreMediaErrors
-        case failedReadJson
-        case failedFetchMedia
+    enum MediaFileManagerError: Error {
+        case NotFoundURL
+        case FailedEncoding
+    }
+    
+    enum PathOption: String {
+        case document
+        case root = "VideoRecorder"
+        case videos = "VideoRecorder/Videos"
+        case videosInfo
     }
     
     static let shared = MediaFileManager()
-    private let fm = FileManager.default
-    private init() { }
+    private let fileManager: FileManager
     
-    public var numberOfVideos: Int {
-        get {
-            do {
-                return try! fetchJson().count
-            }
-        }
+    private init(fileManager: FileManager = FileManager.default) {
+        self.fileManager = fileManager
     }
     
-    func pretty(_ data: Data) {
+    func prettyPrint(videos: [Video]) {
+        let data = try! JSONEncoder().encode(videos)
+        
         if let json = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers),
            let jsonData = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) {
             print(String(decoding: jsonData, as: UTF8.self))
-        } else {
-            print("json data malformed")
         }
     }
     
-    func storeMediaInfo(video: Video) {
-        // create url
-        guard let (dirUrl, fileUrl) = createUrl() else {
-            return
-        }
-        
-        // json file check
-        guard let data = try? Data(contentsOf: fileUrl) else {
+    func createUrl(path: PathOption) -> URL? {
+        if let url = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first {
             do {
-                try fm.createDirectory(at: dirUrl, withIntermediateDirectories: true)
+                var url = url
+                
+                switch path {
+                case .document:
+                    break
+                case .root: // VideoRecorder
+                    url = url.appendingPathComponent(path.rawValue)
+                    try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+                    break
+                    
+                case .videos: // VideoRecorder/Videos
+                    url = url.appendingPathComponent(path.rawValue)
+                    try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+                    break
+                    
+                case .videosInfo: // VideoRecorder/Videos/Videos.json
+                    url = url.appendingPathComponent(PathOption.videos.rawValue)
+                    try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+                    url = url.appendingPathComponent("Videos")
+                    url = url.appendingPathExtension("json")
+                    break
+                    
+                }
+                return url
             } catch {
                 print(error.localizedDescription)
+                return nil
             }
-            putJson(url: fileUrl, originData: nil, newModel: video)
-            return
+        } else {
+            print("Can not create url")
+            return nil
         }
-        
-        putJson(url: fileUrl, originData: data, newModel: video)
     }
     
-//    func fetchJson() -> [Video] {
-//        guard let (_, fileUrl) = createUrl() else { return [] }
-//        guard let data = try? Data(contentsOf: fileUrl) else { return [] }
-//
-//        do {
-//            let decoder = JSONDecoder()
-//            let jsonArray = try decoder.decode([Video].self, from: data)
-//            return jsonArray
-//        } catch {
-//            print(error.localizedDescription)
-//            return []
-//        }
-//    }
+    func addDummy(url outputUrl: URL) -> URL? {
+        guard let docUrl = createUrl(path: .document) else { return nil }
+        let dummyUrl = docUrl.appendingPathComponent("sampleVideo.mp4")
+        do {
+            try fileManager.copyItem(atPath: dummyUrl.relativePath, toPath: outputUrl.relativePath)
+            return outputUrl
+        } catch {
+            print(error.localizedDescription)
+            return nil
+        }
+    }
     
-    func fetchJson() -> [VideoListItemViewModel] {
-        guard let (_, fileUrl) = createUrl() else { return [] }
-        guard let data = try? Data(contentsOf: fileUrl) else { return [] }
-        var videoListItemViewModels = [VideoListItemViewModel]()
+    func getVideos() throws -> [VideoListItemViewModel] {
+        guard let url = createUrl(path: .videosInfo) else {
+            throw MediaFileManagerError.NotFoundURL
+        }
+        
+        guard let data = try? Data(contentsOf: url) else {
+            print("Not found json")
+            return []
+        }
+        
         do {
             let decoder = JSONDecoder()
-            let jsonArray = try decoder.decode([Video].self, from: data)
-            for video in jsonArray {
+            let videos = try decoder.decode([Video].self, from: data)
+            var videoListItemViewModels = [VideoListItemViewModel]()
+            
+            prettyPrint(videos: videos)
+            for video in videos {
                 videoListItemViewModels.append(VideoListItemViewModel(video: video))
             }
             return videoListItemViewModels
@@ -90,68 +115,67 @@ class MediaFileManager {
         }
     }
     
-    private func putJson(url fileUrl: URL, originData old: Data?, newModel new: Video) {
-        let emptyJson = try! JSONEncoder().encode([Video]())
-        do {
-            let decoder = JSONDecoder()
-            let jsonArray = try decoder.decode([Video].self, from: old ?? emptyJson)
-            var json = jsonArray
-                json.append(new)
-            let data = try! JSONEncoder().encode(json)
-            try data.write(to: fileUrl, options: [.atomic])
-            NotificationCenter.default.post(name: Notification.Name("mediaInfo_updated"), object: nil)
-        } catch {
-            print(error.localizedDescription)
+    private func getVideosInfo() throws -> [Video] {
+        guard let url = createUrl(path: .videosInfo) else {
+            throw MediaFileManagerError.NotFoundURL
         }
-    }
-    
-    /// unused method
-    func renameMedia(oldName: String, newName: String) -> URL? {
-        guard let (dirUrl, _) = createUrl() else { return nil }
-        let newUrl = dirUrl.appendingPathComponent("\(newName).mp4")
-        let oldUrl = dirUrl.appendingPathComponent("\(oldName).mp4")
-        do {
-            try FileManager.default.moveItem(atPath: oldUrl.relativePath, toPath: newUrl.relativePath)
-            return newUrl
-        } catch {
-            print(error.localizedDescription)
+        
+        guard let data = try? Data(contentsOf: url) else {
+            print("Not found json")
+            return []
         }
-        return nil
-    }
-    
-    /// local video & json  전부 삭제
-    func deleteMedia(_ id: String) {
-        guard let (dirUrl, fileUrl) = createUrl() else { return }
-        guard let data = try? Data(contentsOf: fileUrl) else { return }
         
         do {
-            let jsonArray = try JSONDecoder().decode([Video].self, from: data)
-            let editedJsonArry = jsonArray.filter { $0.id != id }
-            let data = try! JSONEncoder().encode(editedJsonArry)
-            try data.write(to: fileUrl, options: [.completeFileProtection])
-            let videoUrl = dirUrl.appendingPathComponent(id, conformingTo: .mpeg4Movie)
-            try fm.removeItem(at: videoUrl)
+            let decoder = JSONDecoder()
+            let videos = try decoder.decode([Video].self, from: data)
+            return videos
+        } catch {
+            print(error.localizedDescription)
+            return []
+        }
+    }
+    
+    func addVideo(video: Video) -> Bool {
+        guard let url = createUrl(path: .videosInfo) else { return false }
+        
+        do {
+            var videos = try getVideosInfo()
+            videos.append(video)
+            let data = try! JSONEncoder().encode(videos)
+            try data.write(to: url, options: [.atomic])
+            
+            prettyPrint(videos: [video])
+            return true
         } catch {
             print(error.localizedDescription)
         }
+        return false
     }
-
-    /// dirUrl 영상 저장 URL,  fileUrl json 저장 URL
-    func createUrl() -> (URL, URL)? {
-        if let url = fm.urls(for: .documentDirectory, in: .userDomainMask).first {
-            let dirUrl = url.appendingPathComponent("VideoRecorder")
-            var fileUrl = dirUrl
-            do {
-                try fm.createDirectory(at: dirUrl, withIntermediateDirectories: true)
-                fileUrl.appendPathComponent("Video")
-                fileUrl = fileUrl.appendingPathExtension("json")
-            } catch {
-                print(error.localizedDescription)
+    
+    func deleteVideo(id: String) -> Bool {
+        guard let videosUrl = createUrl(path: .videos) else { return false }
+        guard let jsonUrl = createUrl(path: .videosInfo) else { return false }
+        
+        let videoUrl = videosUrl.appendingPathComponent(id, conformingTo: .mpeg4Movie)
+        do {
+            var videos = try getVideosInfo()
+            // json에서 해당 video정보 제거
+            let data = try JSONEncoder().encode(videos.filter({ $0.id != id }))
+            try data.write(to: jsonUrl, options: [.atomic])
+            
+            prettyPrint(videos: videos.filter { $0.id == id })
+            // 현재 저장된 데이터에서 해당 id가 삭제됬는지 확인 후 로컬 영상 제거
+            videos = try getVideosInfo()
+            if videos.filter({ $0.id == id }).count == 0 {
+                try fileManager.removeItem(at: videoUrl)
+                return !fileManager.fileExists(atPath: videoUrl.relativePath)
+            } else {
+                print("Not deleted data about \(id).mp4")
+                return false
             }
-            return (dirUrl, fileUrl)
-        } else {
-            print("No return url.")
-            return nil
+        } catch {
+            print(error.localizedDescription)
         }
+        return false
     }
 }

--- a/VideoRecorder/Utils/ThumbnailMaker.swift
+++ b/VideoRecorder/Utils/ThumbnailMaker.swift
@@ -28,10 +28,11 @@ class ThumbnailMaker {
     func generateThumnailAsync(filename: String, startOffsets: [Double],
                                completion: @escaping (UIImage) -> Void) {
         
-        guard let (dirUrl, _) = MediaFileManager.shared.createUrl() else { return }
-        let fileUrl = dirUrl.appendingPathComponent(filename, conformingTo: .mpeg4Movie)
         
-        let asset = AVAsset(url: fileUrl)
+        var dirUrl = MediaFileManager.shared.createUrl(path: .videos)
+        dirUrl = dirUrl!.appendingPathComponent(filename, conformingTo: .mpeg4Movie)
+        
+        let asset = AVAsset(url: dirUrl!)
         let imageGenerator = self.imageGenerator(asset: asset)
 
         let time: [NSValue] = startOffsets.compactMap {

--- a/VideoRecorder/Utils/UIViewController+extension.swift
+++ b/VideoRecorder/Utils/UIViewController+extension.swift
@@ -21,6 +21,7 @@ extension UIViewController {
         objc_setAssociatedObject(self, &textHandlerKey, textChangeHandler, .OBJC_ASSOCIATION_RETAIN)
 
         alertController.addTextField { textField in
+            textField.accessibilityIdentifier = "filename"
             textField.placeholder = placeholder
             textField.clearButtonMode = .whileEditing
             textField.borderStyle = .none
@@ -34,6 +35,7 @@ extension UIViewController {
             okHandler(text)
             objc_setAssociatedObject(self, &textHandlerKey, nil, .OBJC_ASSOCIATION_RETAIN)
         })
+        okAction.accessibilityIdentifier = "filename_ok"
         okAction.isEnabled = false
         alertController.addAction(okAction)
 
@@ -44,7 +46,6 @@ extension UIViewController {
 
         present(alertController, animated: true, completion: nil)
     }
-
 }
 
 class TextFieldTextChangeHandler {


### PR DESCRIPTION
## 개요

- fix 비디오 리스트 업데이트 이슈
    - backup 완료시점에 binding데이터 수정하도록함.
- Video 관련 기능 MediaFileManager, FirebaseStorageManager의 함수 개선
    - 함수명 일관되게 수정 및 명확한 기능을 수행하게끔 개선
        - media 단어를 video로 수정
        - backup 함수에 completion 추가
        - CreateUrl함수는 이제 option에따라 한개의 URL을 반환
    - Recording test 함수 수정
        - test_after_..rename → test_finish_recording
            - 가독성 개선및 이전 함수들 새 함수로 대체
- UITest를 위한 준비
    - UITest에서 element query를 위한 accessibilityIdentifier 지정

## 예상 리뷰시간

- Over 10min

## Issue

- -

## Point

- MediaFileManager.swift
- FirebaseStorageManager.swift
- RecordViewController

## ScreenShot

- -

## Test

- 녹화본 리스트 업데이트 테스트
    - [x]  녹화 저장후 백업이 `완료된 후` 리스트로 복귀하여 업데이트 확인
    - [x]  녹화 저장후 백업이 `완료되기 전` 리스트로 복귀하여 업데이트 확인
- 개선된 Video 관련 함수들 테스트
    - [x]  FileManager를 이용한 Video, VideoInfo CRUD
    - [x]  FireStorage와 BackgroundTask를 이용한 Video 백업, 삭제